### PR TITLE
Fixed lack of Rate Limiting in apostrophe

### DIFF
--- a/lib/modules/apostrophe-login/index.js
+++ b/lib/modules/apostrophe-login/index.js
@@ -139,6 +139,14 @@ var qs = require('qs');
 var Promise = require('bluebird');
 var async = require('async');
 var moment = require('moment');
+const rateLimit = require('express-rate-limit');
+
+const loginLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 20,
+  message: 'You have exceeded the rate limit. Please try after some time!',
+  headers: true
+});
 
 module.exports = {
 
@@ -601,7 +609,7 @@ module.exports = {
           }
         });
 
-        self.apos.app.post('/login',
+        self.apos.app.post('/login',loginLimiter,
           async function(req, res, next) {
             try {
               await self.emit('before', req);
@@ -971,7 +979,7 @@ module.exports = {
           list.push('/confirm-totp');
         });
 
-        self.apos.app.post('/login-totp', function(req, res, next) {
+        self.apos.app.post('/login-totp',loginLimiter, function(req, res, next) {
           // People type the space shown in the app a lot
           req.body.code = self.apos.launder.string(req.body.code);
           req.body.code = req.body.code.replace(/\s+/g, '');

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "cli-progress": "^2.1.1",
     "connect-flash": "^0.1.1",
     "connect-multiparty": "^2.2.0",
+    "express-rate-limit": "^5.2.3",
     "cookie-parser": "^1.4.5",
     "credential": "^2.0.0",
     "cuid": "^1.3.8",


### PR DESCRIPTION
### 📊 Metadata *
Fixed ```Lack of Rate Limiting```.
#### Bounty URL: https://www.huntr.dev/bounties/1-npm-apostrophe/

### ⚙️ Description *
```ApostropheCMS``` is a content management system (CMS) for Node.js. It supports in-context editing, schema-driven content types, flexible widgets and a great deal more. This module contains everything necessary to build a website with ApostropheCMS. This package lacks rate-limiting, which allows an attacker to brute-force admin login credentials.

### 🐛 Proof of Concept (PoC) *
1. Setup a demo project using ApostropheCMS by following these instructions https://docs.apostrophecms.org/getting-started/setting-up-your-environment.html
2.
 ```
sudo npm i -g apostrophe-cli
apos create-project test-project
cd test-project
npm i
node app.js apostrophe-users:add admin admin
node app.js 
```
3. Navigate to ```http://localhost:3000/login``` and capture the POST request in Burp
4. Use intruder and brute-force password 

https://raw.githubusercontent.com/arjunshibu/files/main/apostrophe-poc.png
### 🔥 Proof of Fix (PoF) *
Implemented rate limiting using ```express-rate-limit```

### 👍 User Acceptance Testing (UAT)

_Run a unit test or a legitimate use case to prove that your fix does not introduce breaking changes._
